### PR TITLE
ignore columns by field name 

### DIFF
--- a/tableExport.js
+++ b/tableExport.js
@@ -815,8 +815,8 @@
                  $(this).css('visibility') != 'hidden' &&
                  $(this).data("tableexport-display") != 'none')) {
               if (defaults.ignoreColumn.length == 0 ||
-                  (isColumnNotIgnoredByFieldName($row, colIndex, headers) &&
-                  isColumnNotIgnoredByIndex($row, colIndex))) {
+                  isColumnNotIgnoredByFieldName($row, colIndex, headers) ||
+                  isColumnNotIgnoredByIndex($row, colIndex)) {
                 if (typeof (cellcallback) === "function") {
                   var c, Colspan = 0;
                   var r, Rowspan = 0;

--- a/tableExport.js
+++ b/tableExport.js
@@ -783,13 +783,13 @@
         return result;
       }
 
-      function isColumnIgnoredByFieldName($row, colIndex, headers) {
+      function isColumnNotIgnoredByFieldName($row, colIndex, headers) {
         return typeof defaults.ignoreColumn[0] == 'string' &&
             $.inArray(headers[colIndex], defaults.ignoreColumn) == -1 &&
             $.inArray(headers[colIndex-$row.length], defaults.ignoreColumn) == -1;
       }
 
-      function isColumnIgnoredByIndex($row, colIndex) {
+      function isColumnNotIgnoredByIndex($row, colIndex) {
         return typeof defaults.ignoreColumn[0] == 'number' &&
             $.inArray(colIndex, defaults.ignoreColumn) == -1 &&
             $.inArray(colIndex-$row.length, defaults.ignoreColumn) == -1;
@@ -815,8 +815,8 @@
                  $(this).css('visibility') != 'hidden' &&
                  $(this).data("tableexport-display") != 'none')) {
               if (defaults.ignoreColumn.length == 0 ||
-                  isColumnIgnoredByFieldName($row, colIndex, headers) ||
-                  isColumnIgnoredByIndex($row, colIndex)) {
+                  (isColumnNotIgnoredByFieldName($row, colIndex, headers) &&
+                  isColumnNotIgnoredByIndex($row, colIndex))) {
                 if (typeof (cellcallback) === "function") {
                   var c, Colspan = 0;
                   var r, Rowspan = 0;


### PR DESCRIPTION
Hi,

It seems that ignoreColumn doesn't work too well with showColumns from bootstrap-table. 
For example, if you use `ignoreColumn: [0, 2]` and the user uses the showColumns dropdown to hide column 0, the resulting columns in the csv will be shifted ignoring column 1 and 3 instead of the hidden 0 and 2.

Here is a PR to ignore columns based on field name (i.e. `ignoreColumn: ['id', 'name']`) instead of the index of the column. I have just realized that the plugin is intended to be used with any html table so I made the code work both for field names and indexes. I though it was only useful for bootstrap-table. Anyway, if you like the PR, I can always add a paragraph in the README to explain how to ignore column by field name. Any suggestion to improve the PR is of course welcome. 

Thank you
