### PR TITLE
Fix number parsing when hmtl.decimalMark and default thousandsSeparator are equal

### DIFF
--- a/tableExport.js
+++ b/tableExport.js
@@ -1385,8 +1385,8 @@
 
       function parseNumber(value) {
         value = value || "0";
-        value = replaceAll(value, defaults.numbers.html.decimalMark, '.');
         value = replaceAll(value, defaults.numbers.html.thousandsSeparator, '');
+        value = replaceAll(value, defaults.numbers.html.decimalMark, '.');
 
         return typeof value === "number" || jQuery.isNumeric(value) !== false ? value : false;
       }


### PR DESCRIPTION
If html.decimalMark is the same symbol as the default thousadsSeparator
all symbols get removed and the parsed number is then incorrect.

This is the case when converting from german locale.

E.g.: with html decimalMark ',' thousandsSeparator '.' (german locale)
     and output decimalMark '.' thousandsSeparator ',' (english locale):
1.200,50 -> 120050 -> 120,050
 (input) (raw number) (output)